### PR TITLE
Fix: Disable A/B testing to allow CMS content display

### DIFF
--- a/src/hooks/useABTesting.ts
+++ b/src/hooks/useABTesting.ts
@@ -149,7 +149,7 @@ export const AB_TESTS = {
     id: 'hero_cta_button',
     name: 'Hero CTA Button Text',
     description: 'Test different CTA button text on hero section',
-    enabled: true,
+    enabled: false,
     variants: [
       { 
         id: 'control', 
@@ -173,7 +173,7 @@ export const AB_TESTS = {
     id: 'hero_headline',
     name: 'Hero Headline',
     description: 'Test different hero headlines',
-    enabled: true,
+    enabled: false,
     variants: [
       {
         id: 'control',


### PR DESCRIPTION
## Summary
• Disabled hero section A/B tests (HERO_CTA_BUTTON and HERO_HEADLINE)
• Resolves issue where test variants were overriding authentic CMS content  
• Hero now properly displays "TechOps for everyone" from Sanity CMS

## Test plan
- [x] Verified CMS content displays correctly in hero section
- [x] Confirmed A/B testing is disabled for hero elements
- [x] Tested that fallback content still works if CMS unavailable

🤖 Generated with [Claude Code](https://claude.ai/code)