### PR TITLE
Feat: Add CMS-friendly gradient marker system for hero titles

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -66,11 +66,13 @@ export function HeroSection() {
               return heroData.title
             })()
             
+            // Parse gradient markers: *word* becomes gradient
             return displayTitle.split(' ').map((word, index) => {
-              if (word.toLowerCase() === 'idea' || word.toLowerCase() === 'product' || word.toLowerCase() === 'operations' || word.toLowerCase() === 'operational') {
+              if (word.startsWith('*') && word.endsWith('*') && word.length > 2) {
+                const cleanWord = word.slice(1, -1)
                 return (
                   <span key={index} className="bg-gradient-to-r from-pb-accent to-pb-electric bg-clip-text text-transparent">
-                    {word}{' '}
+                    {cleanWord}{' '}
                   </span>
                 )
               }


### PR DESCRIPTION
## Summary
• Replaced hardcoded word matching with flexible `*word*` marker syntax
• Content editors can now apply gradient styling to any word in the CMS
• Example: `*TechOps* for everyone` makes "TechOps" gradient styled
• Provides complete freedom from specific word dependencies

## Test plan
- [x] Verified marker system parses `*word*` syntax correctly
- [x] Confirmed gradient styling applies to marked words
- [x] Tested that unmarked words display normally

🤖 Generated with [Claude Code](https://claude.ai/code)