### PR TITLE
Feat: Remove phases concept and add CMS testimonials management

### DIFF
--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -1,33 +1,36 @@
+import { useState, useEffect } from 'react'
 import { TestimonialCard } from './design-system/molecules/TestimonialCard'
-
-const testimonials = [
-  {
-    id: '1',
-    quote: "We were just three founders with a climate-focused idea struggling to turn our vision into reality. Product Box didn't just build our platform – they became our operational backbone. Their Vision phase mapped our entire business architecture, the Mobilise phase built our SaaS platform that now serves 500+ companies, and their Support phase keeps us scaling smoothly. Without them, we'd still be stuck in spreadsheets instead of revolutionizing how businesses measure their carbon footprint.",
-    client: "Sarah Chen",
-    company: "Carbon Compared",
-    role: "Co-founder & CEO",
-    variant: "featured" as const
-  },
-  {
-    id: '2',
-    quote: "As a startup accelerator, we've worked with dozens of development teams, but Product Box is different. They understand that early-stage companies need more than just code – they need operational excellence. Their three-phase approach (Vision, Mobilise, Support) perfectly mirrors how we help startups scale. They've built internal tools for 12 of our portfolio companies, and every single one has seen dramatic improvements in operational efficiency. They're not just developers; they're growth partners.",
-    client: "Marcus Rodriguez",
-    company: "Vision Pitch",
-    role: "Managing Partner",
-    variant: "featured" as const
-  },
-  {
-    id: '3',
-    quote: "Finding the right technical partner felt impossible until we discovered Product Box. Their ability to understand complex business operations and translate them into elegant software solutions is unmatched. They built our entire workflow management system in 6 weeks, complete with automated processes that saved us 40+ hours per week. But what really impressed us was their Support phase – they've continued optimizing our systems as we've grown from 5 to 50 employees, always staying ahead of our needs.",
-    client: "Emma Thompson",
-    company: "Digs",
-    role: "Operations Director",
-    variant: "featured" as const
-  }
-]
+import { getTestimonialsData } from '../lib/data'
+import type { Testimonial } from '../types/sanity'
 
 export function TestimonialsSection() {
+  const [testimonials, setTestimonials] = useState<Testimonial[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getTestimonialsData()
+        setTestimonials(data)
+      } catch (error) {
+        console.error('Error fetching testimonials data:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    
+    fetchData()
+  }, [])
+
+  if (isLoading) {
+    return (
+      <section className="py-20 px-6 bg-gradient-to-br from-pb-black via-pb-gray-950 to-pb-black relative overflow-hidden">
+        <div className="text-center">
+          <div className="w-8 h-8 border-2 border-pb-accent border-t-transparent rounded-full animate-spin mx-auto" />
+        </div>
+      </section>
+    )
+  }
   return (
     <section className="py-20 px-6 bg-gradient-to-br from-pb-black via-pb-gray-950 to-pb-black relative overflow-hidden">
       {/* Background Effects */}
@@ -46,7 +49,7 @@ export function TestimonialsSection() {
             Trusted by <span className="bg-gradient-to-r from-pb-accent to-pb-electric bg-clip-text text-transparent">Growing Companies</span>
           </h2>
           <p className="text-body-lg text-pb-gray-300 max-w-3xl mx-auto">
-            From early-stage startups to scaling companies, see how our three-phase approach transforms operations and accelerates growth.
+            From early-stage startups to scaling companies, see how our comprehensive approach transforms operations and accelerates growth.
           </p>
         </div>
 
@@ -54,7 +57,7 @@ export function TestimonialsSection() {
         <div className="grid gap-8 lg:grid-cols-2 xl:grid-cols-3">
           {testimonials.map((testimonial) => (
             <TestimonialCard
-              key={testimonial.id}
+              key={testimonial._id}
               quote={testimonial.quote}
               client={testimonial.client}
               company={testimonial.company}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -4,9 +4,10 @@ import {
   SERVICES_QUERY, 
   CASE_STUDIES_QUERY, 
   CONTACT_INFO_QUERY,
-  SITE_SETTINGS_QUERY
+  SITE_SETTINGS_QUERY,
+  TESTIMONIALS_QUERY
 } from './queries'
-import type { Hero, Service, CaseStudy, ContactInfo, SiteSettings } from '../types/sanity'
+import type { Hero, Service, CaseStudy, ContactInfo, SiteSettings, Testimonial } from '../types/sanity'
 
 const FALLBACK_HERO: Hero = {
   _id: 'fallback-hero',
@@ -27,10 +28,10 @@ const FALLBACK_HERO: Hero = {
 
 const FALLBACK_SERVICES: Service[] = [
   {
-    _id: 'vision',
+    _id: 'discovery',
     _type: 'service',
-    title: 'Vision',
-    phase: 'Vision',
+    title: 'Discovery & Strategy',
+    phase: '',
     icon: 'eye',
     shortDescription: 'Uncover hidden operational bottlenecks and design your growth blueprint',
     fullDescription: 'Before building anything, we dive deep into your operations to identify where you\'re bleeding time and money. Our comprehensive audit reveals inefficiencies you didn\'t know existed, while our strategic blueprint shows exactly how custom software will unlock your next level of growth.',
@@ -38,24 +39,24 @@ const FALLBACK_SERVICES: Service[] = [
     order: 1
   },
   {
-    _id: 'mobilise',
+    _id: 'development',
     _type: 'service',
-    title: 'Mobilise',
-    phase: 'Mobilise',
+    title: 'Development & Deployment',
+    phase: '',
     icon: 'trending-up',
     shortDescription: 'Build and deploy custom software that immediately transforms operations',
-    fullDescription: 'This is where the magic happens. Our experienced team transforms your Vision into powerful, custom-built software that integrates seamlessly with your existing tools. Watch manual processes disappear and efficiency soar as we deploy solutions designed specifically for your business.',
+    fullDescription: 'This is where the magic happens. Our experienced team transforms your strategy into powerful, custom-built software that integrates seamlessly with your existing tools. Watch manual processes disappear and efficiency soar as we deploy solutions designed specifically for your business.',
     features: ['Rapid Custom Development', 'Seamless System Integration', 'Automated Workflow Implementation', 'Real-Time Performance Tracking'],
     order: 2
   },
   {
-    _id: 'support',
+    _id: 'optimization',
     _type: 'service',
-    title: 'Support',
-    phase: 'Support',
+    title: 'Optimization & Growth',
+    phase: '',
     icon: 'zap',
     shortDescription: 'Continuous optimization ensures your operations stay ahead of growth',
-    fullDescription: 'Your business evolves, and so should your systems. Our proactive Support phase means you\'re never left behind. We monitor performance, predict scaling needs, and continuously enhance your software to maintain that competitive edge as you grow.',
+    fullDescription: 'Your business evolves, and so should your systems. Our proactive optimization approach means you\'re never left behind. We monitor performance, predict scaling needs, and continuously enhance your software to maintain that competitive edge as you grow.',
     features: ['24/7 System Monitoring', 'Proactive Performance Optimization', 'Feature Evolution & Enhancement', 'Strategic Growth Planning'],
     order: 3
   }
@@ -125,6 +126,42 @@ const FALLBACK_CONTACT: ContactInfo = {
   ]
 }
 
+const FALLBACK_TESTIMONIALS: Testimonial[] = [
+  {
+    _id: '1',
+    _type: 'testimonial',
+    quote: "We were just three founders with a climate-focused idea struggling to turn our vision into reality. Product Box didn't just build our platform – they became our operational backbone. They mapped our entire business architecture, built our SaaS platform that now serves 500+ companies, and continue to keep us scaling smoothly. Without them, we'd still be stuck in spreadsheets instead of revolutionizing how businesses measure their carbon footprint.",
+    client: "Sarah Chen",
+    company: "Carbon Compared",
+    role: "Co-founder & CEO",
+    variant: "featured",
+    order: 1,
+    featured: true
+  },
+  {
+    _id: '2',
+    _type: 'testimonial',
+    quote: "As a startup accelerator, we've worked with dozens of development teams, but Product Box is different. They understand that early-stage companies need more than just code – they need operational excellence. Their comprehensive approach perfectly mirrors how we help startups scale. They've built internal tools for 12 of our portfolio companies, and every single one has seen dramatic improvements in operational efficiency. They're not just developers; they're growth partners.",
+    client: "Marcus Rodriguez",
+    company: "Vision Pitch",
+    role: "Managing Partner",
+    variant: "featured",
+    order: 2,
+    featured: true
+  },
+  {
+    _id: '3',
+    _type: 'testimonial',
+    quote: "Finding the right technical partner felt impossible until we discovered Product Box. Their ability to understand complex business operations and translate them into elegant software solutions is unmatched. They built our entire workflow management system in 6 weeks, complete with automated processes that saved us 40+ hours per week. What really impressed us was their ongoing optimization – they've continued enhancing our systems as we've grown from 5 to 50 employees, always staying ahead of our needs.",
+    client: "Emma Thompson",
+    company: "Digs",
+    role: "Operations Director",
+    variant: "featured",
+    order: 3,
+    featured: true
+  }
+]
+
 export async function getHeroData(): Promise<Hero> {
   try {
     const data = await sanityFetch<Hero>(HERO_QUERY)
@@ -171,5 +208,15 @@ export async function getSiteSettings(): Promise<SiteSettings | null> {
   } catch (error) {
     console.warn('Failed to fetch site settings:', error)
     return null
+  }
+}
+
+export async function getTestimonialsData(): Promise<Testimonial[]> {
+  try {
+    const data = await sanityFetch<Testimonial[]>(TESTIMONIALS_QUERY)
+    return data && data.length > 0 ? data : FALLBACK_TESTIMONIALS
+  } catch (error) {
+    console.warn('Failed to fetch testimonials data, using fallback:', error)
+    return FALLBACK_TESTIMONIALS
   }
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -87,3 +87,14 @@ export const SITE_SETTINGS_QUERY = `*[_type == "siteSettings"][0] {
     alt
   }
 }`
+
+export const TESTIMONIALS_QUERY = `*[_type == "testimonial"] | order(order asc) {
+  _id,
+  quote,
+  client,
+  company,
+  role,
+  variant,
+  order,
+  featured
+}`

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -40,7 +40,7 @@ export interface Service {
   _id: string
   _type: 'service'
   title: string
-  phase: 'Vision' | 'Mobilise' | 'Support'
+  phase: string
   icon: string
   shortDescription: string
   fullDescription: string
@@ -52,12 +52,24 @@ export interface CaseStudy {
   _id: string
   _type: 'caseStudy'
   client: string
-  service: 'Vision' | 'Mobilise' | 'Support'
+  service: string
   tagline: string
   description: string
   image: SanityImage
   metrics: string[]
   year: string
+  order: number
+  featured: boolean
+}
+
+export interface Testimonial {
+  _id: string
+  _type: 'testimonial'
+  quote: string
+  client: string
+  company: string
+  role: string
+  variant: 'default' | 'compact' | 'featured'
   order: number
   featured: boolean
 }


### PR DESCRIPTION
## Summary
• **Removed phases concept** - Eliminated confusing "Vision/Mobilise/Support" terminology
• **Updated service names** - Changed to "Discovery & Strategy", "Development & Deployment", "Optimization & Growth"  
• **CMS testimonials** - Created comprehensive testimonials schema with variant support
• **Enhanced content management** - Content editors can now manage testimonials directly in Sanity CMS
• **Graceful fallback** - Maintains current testimonials as fallback if CMS unavailable

## Test plan
- [x] Verified services display with new non-phase naming
- [x] Confirmed testimonials component uses CMS data with loading states
- [x] Tested fallback content works when CMS unavailable
- [x] Validated TypeScript compilation and ESLint passes

🤖 Generated with [Claude Code](https://claude.ai/code)