### PR TITLE
Fix service title text wrapping for Mobilise and Support

### DIFF
--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -30,7 +30,7 @@ function ServiceCard({
               </div>
               <div className="w-12 h-0.5 bg-gradient-to-r from-pb-accent to-pb-electric" />
             </div>
-            <h3 className="text-h1 lg:text-hero font-black text-pb-white mb-6 lg:mb-8 break-words hyphens-auto group-hover:text-pb-accent transition-colors duration-300">
+            <h3 className="text-h1 lg:text-hero font-black text-pb-white mb-6 lg:mb-8 text-wrap-balance avoid-orphans leading-tight no-break-short group-hover:text-pb-accent transition-colors duration-300">
               {service.title}
             </h3>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,12 @@
     word-spacing: 0.1em;
     letter-spacing: -0.01em;
   }
+  
+  .no-break-short {
+    word-break: keep-all;
+    overflow-wrap: break-word;
+    hyphens: none;
+  }
 
   /* Custom animations for interactive elements */
   @keyframes fade-in {


### PR DESCRIPTION
## Summary
- Fixed awkward text wrapping in service titles for "Mobilise" and "Support" services
- Added `no-break-short` CSS utility class to prevent inappropriate word breaks
- Enhanced typography with better text balancing and orphan prevention

## Changes
- Updated `ServiceCards.tsx` to include `no-break-short` class in service title styling
- Added CSS utility class in `index.css` with `word-break: keep-all` and `overflow-wrap: break-word`
- Combined with existing `text-wrap-balance` and `avoid-orphans` for optimal text display

## Testing
- Service titles now display without awkward line breaks
- Text wrapping is more visually appealing and maintains readability
- CSS changes are scoped to prevent impact on other components

🤖 Generated with [Claude Code](https://claude.ai/code)